### PR TITLE
fixes some recipes that would always run with any circuit number

### DIFF
--- a/src/main/java/gregicadditions/recipes/categories/SuperconductorRecipes.java
+++ b/src/main/java/gregicadditions/recipes/categories/SuperconductorRecipes.java
@@ -68,7 +68,7 @@ public class SuperconductorRecipes {
                     .input(wireGtSingle, MVSuperconductorBase, 3)
                     .input(pipeTiny, StainlessSteel, 2)
                     .inputs(ELECTRIC_PUMP_MV.getStackForm(2))
-                    .notConsumable(IntCircuitIngredient.getIntegratedCircuit(1))
+                    .notConsumable(new IntCircuitIngredient(1))
                     .fluidInputs(Nitrogen.getFluid(2000))
                     .output(wireGtSingle, MVSuperconductor, 3)
                     .buildAndRegister();
@@ -77,7 +77,7 @@ public class SuperconductorRecipes {
                     .input(wireGtSingle, HVSuperconductorBase, 3)
                     .input(pipeTiny, Titanium, 2)
                     .inputs(ELECTRIC_PUMP_HV.getStackForm())
-                    .notConsumable(IntCircuitIngredient.getIntegratedCircuit(1))
+                    .notConsumable(new IntCircuitIngredient(1))
                     .fluidInputs(Nitrogen.getFluid(2000))
                     .output(wireGtSingle, HVSuperconductor, 3)
                     .buildAndRegister();
@@ -86,7 +86,7 @@ public class SuperconductorRecipes {
                     .input(wireGtSingle, EVSuperconductorBase, 9)
                     .input(pipeTiny, TungstenSteel, 6)
                     .inputs(ELECTRIC_PUMP_EV.getStackForm(2))
-                    .notConsumable(IntCircuitIngredient.getIntegratedCircuit(1))
+                    .notConsumable(new IntCircuitIngredient(1))
                     .fluidInputs(LiquidNitrogen.getFluid(6000))
                     .output(wireGtSingle, EVSuperconductor, 9)
                     .buildAndRegister();
@@ -95,7 +95,7 @@ public class SuperconductorRecipes {
                     .input(wireGtSingle, IVSuperconductorBase, 6)
                     .input(pipeTiny, NiobiumTitanium, 4)
                     .inputs(ELECTRIC_PUMP_IV.getStackForm())
-                    .notConsumable(IntCircuitIngredient.getIntegratedCircuit(1))
+                    .notConsumable(new IntCircuitIngredient(1))
                     .fluidInputs(LiquidNitrogen.getFluid(6000))
                     .output(wireGtSingle, IVSuperconductor, 6)
                     .buildAndRegister();
@@ -104,7 +104,7 @@ public class SuperconductorRecipes {
                     .input(wireGtSingle, LuVSuperconductorBase, 8)
                     .input(pipeTiny, Enderium, 5)
                     .inputs(ELECTRIC_PUMP_LUV.getStackForm())
-                    .notConsumable(IntCircuitIngredient.getIntegratedCircuit(1))
+                    .notConsumable(new IntCircuitIngredient(1))
                     .fluidInputs(LiquidNitrogen.getFluid(6000))
                     .output(wireGtSingle, LuVSuperconductor, 8)
                     .buildAndRegister();
@@ -113,7 +113,7 @@ public class SuperconductorRecipes {
                     .input(wireGtSingle, ZPMSuperconductorBase, 16)
                     .input(pipeTiny, Naquadah, 6)
                     .inputs(ELECTRIC_PUMP_ZPM.getStackForm())
-                    .notConsumable(IntCircuitIngredient.getIntegratedCircuit(1))
+                    .notConsumable(new IntCircuitIngredient(1))
                     .fluidInputs(LiquidHelium.getFluid(8000))
                     .output(wireGtSingle, ZPMSuperconductor, 16)
                     .buildAndRegister();
@@ -122,7 +122,7 @@ public class SuperconductorRecipes {
                     .input(wireGtSingle, UVSuperconductorBase, 32)
                     .input(pipeTiny, Ultimet, 7)
                     .inputs(ELECTRIC_PUMP_UV.getStackForm())
-                    .notConsumable(IntCircuitIngredient.getIntegratedCircuit(1))
+                    .notConsumable(new IntCircuitIngredient(1))
                     .fluidInputs(LiquidHelium.getFluid(10000))
                     .output(wireGtSingle, UVSuperconductor, 32)
                     .buildAndRegister();
@@ -131,7 +131,7 @@ public class SuperconductorRecipes {
                     .input(wireGtSingle, UHVSuperconductorBase, 32)
                     .input(pipeTiny, Zeron100, 8)
                     .inputs(ELECTRIC_PUMP_UHV.getStackForm())
-                    .notConsumable(IntCircuitIngredient.getIntegratedCircuit(1))
+                    .notConsumable(new IntCircuitIngredient(1))
                     .fluidInputs(LiquidHelium.getFluid(12000))
                     .output(wireGtSingle, UHVSuperconductor, 32)
                     .buildAndRegister();
@@ -140,7 +140,7 @@ public class SuperconductorRecipes {
                     .input(wireGtSingle, UEVSuperconductorBase, 32)
                     .input(pipeTiny, Lafium, 9)
                     .inputs(ELECTRIC_PUMP_UEV.getStackForm())
-                    .notConsumable(IntCircuitIngredient.getIntegratedCircuit(1))
+                    .notConsumable(new IntCircuitIngredient(1))
                     .fluidInputs(MicrocrystallizingHydrogen.getFluid(14000))
                     .output(wireGtSingle, UEVSuperconductor, 32)
                     .buildAndRegister();
@@ -149,7 +149,7 @@ public class SuperconductorRecipes {
                     .input(wireGtSingle, UIVSuperconductorBase, 32)
                     .input(pipeTiny, TantalumHafniumSeaborgiumCarbide, 10)
                     .inputs(ELECTRIC_PUMP_UIV.getStackForm())
-                    .notConsumable(IntCircuitIngredient.getIntegratedCircuit(1))
+                    .notConsumable(new IntCircuitIngredient(1))
                     .fluidInputs(MicrocrystallizingHydrogen.getFluid(16000))
                     .output(wireGtSingle, UIVSuperconductor, 32)
                     .buildAndRegister();
@@ -158,7 +158,7 @@ public class SuperconductorRecipes {
                     .input(wireGtSingle, UMVSuperconductorBase, 32)
                     .input(pipeTiny, Neutronium, 11)
                     .inputs(ELECTRIC_PUMP_UMV.getStackForm())
-                    .notConsumable(IntCircuitIngredient.getIntegratedCircuit(1))
+                    .notConsumable(new IntCircuitIngredient(1))
                     .fluidInputs(MicrocrystallizingHydrogen.getFluid(18000))
                     .output(wireGtSingle, UMVSuperconductor, 32)
                     .buildAndRegister();
@@ -167,7 +167,7 @@ public class SuperconductorRecipes {
                     .input(wireGtSingle, UXVSuperconductorBase, 32)
                     .input(pipeTiny, Neutronium, 12)
                     .inputs(ELECTRIC_PUMP_UXV.getStackForm())
-                    .notConsumable(IntCircuitIngredient.getIntegratedCircuit(1))
+                    .notConsumable(new IntCircuitIngredient(1))
                     .fluidInputs(FreeElectronGas.getFluid(20000))
                     .output(wireGtSingle, UXVSuperconductor, 32)
                     .buildAndRegister();
@@ -176,7 +176,7 @@ public class SuperconductorRecipes {
                     .input(wireGtSingle, UXVSuperconductorBase, 64)
                     .input(pipeTiny, Neutronium, 13)
                     .inputs(ELECTRIC_PUMP_MAX.getStackForm())
-                    .notConsumable(IntCircuitIngredient.getIntegratedCircuit(2))
+                    .notConsumable(new IntCircuitIngredient(2))
                     .fluidInputs(FreeElectronGas.getFluid(22000))
                     .output(wireGtSingle, Superconductor, 64)
                     .buildAndRegister();

--- a/src/main/java/gregicadditions/recipes/chain/HNIWChain.java
+++ b/src/main/java/gregicadditions/recipes/chain/HNIWChain.java
@@ -236,7 +236,7 @@ public class HNIWChain {
         CHEMICAL_RECIPES.recipeBuilder()
                 .fluidInputs(Formaldehyde.getFluid(6000))
                 .fluidInputs(Ammonia.getFluid(4000))
-                .notConsumable(IntCircuitIngredient.getIntegratedCircuit(1))
+                .notConsumable(new IntCircuitIngredient(1))
                 .outputs(Hexamethylenetetramine.getItemStack(22))
                 .fluidOutputs(Water.getFluid(6000))
                 .EUt(480)

--- a/src/main/java/gregicadditions/recipes/chain/NanotubeChain.java
+++ b/src/main/java/gregicadditions/recipes/chain/NanotubeChain.java
@@ -81,7 +81,7 @@ public class NanotubeChain {
         // CH2O + 2C2H4O + NH3 -> C5H5N + 3H2O + 2H
         LARGE_CHEMICAL_RECIPES.recipeBuilder().duration(240).EUt(1920)
                 .notConsumable(ThalliumChloride.getItemStack())
-                .notConsumable(IntCircuitIngredient.getIntegratedCircuit(1))
+                .notConsumable(new IntCircuitIngredient(1))
                 .fluidInputs(Formaldehyde.getFluid(1000))
                 .fluidInputs(Acetaldehyde.getFluid(2000))
                 .fluidInputs(Ammonia.getFluid(1000))

--- a/src/main/java/gregicadditions/recipes/chain/UltimateMaterials.java
+++ b/src/main/java/gregicadditions/recipes/chain/UltimateMaterials.java
@@ -307,14 +307,14 @@ public class UltimateMaterials {
 
         STELLAR_FORGE_RECIPES.recipeBuilder().duration(10).EUt(10000000)
                 .inputs(COSMIC_FABRIC.getStackForm())
-                .notConsumable(IntCircuitIngredient.getIntegratedCircuit(1))
+                .notConsumable(new IntCircuitIngredient(1))
                 .inputs(GAMetaBlocks.EXPLOSIVE.getItemVariant(GAExplosive.ExplosiveType.QCD_CHARGE))
                 .fluidOutputs(CosmicMeshPlasma.getFluid(1000))
                 .buildAndRegister();
 
         STELLAR_FORGE_RECIPES.recipeBuilder().duration(10).EUt(10000000)
                 .inputs(COSMIC_MESH.getStackForm())
-                .notConsumable(IntCircuitIngredient.getIntegratedCircuit(1))
+                .notConsumable(new IntCircuitIngredient(1))
                 .inputs(GAMetaBlocks.EXPLOSIVE.getItemVariant(GAExplosive.ExplosiveType.QCD_CHARGE))
                 .fluidOutputs(CosmicMeshPlasma.getFluid(1000))
                 .buildAndRegister();

--- a/src/main/java/gregicadditions/recipes/chain/VariousChains.java
+++ b/src/main/java/gregicadditions/recipes/chain/VariousChains.java
@@ -356,7 +356,7 @@ public class VariousChains {
         CHEMICAL_RECIPES.recipeBuilder().duration(125).EUt(120)
                 .input(dust, Lithium)
                 .fluidInputs(Chlorine.getFluid(1000))
-                .notConsumable(IntCircuitIngredient.getIntegratedCircuit(1))
+                .notConsumable(new IntCircuitIngredient(1))
                 .outputs(LithiumChloride.getItemStack(2))
                 .buildAndRegister();
 
@@ -364,7 +364,7 @@ public class VariousChains {
         CHEMICAL_RECIPES.recipeBuilder().duration(100).EUt(30)
                 .input(dust, Aluminium)
                 .fluidInputs(Chlorine.getFluid(3000))
-                .notConsumable(IntCircuitIngredient.getIntegratedCircuit(1))
+                .notConsumable(new IntCircuitIngredient(1))
                 .outputs(AluminiumChloride.getItemStack(4))
                 .buildAndRegister();
     }


### PR DESCRIPTION
this mainly affected superconductors, now large assembler should be able to run both starlight and nitrogen recipes at the same time without conflicts