### PR TITLE
fix calcium dupe

### DIFF
--- a/src/main/java/gregicadditions/recipes/chain/BariumChain.java
+++ b/src/main/java/gregicadditions/recipes/chain/BariumChain.java
@@ -88,7 +88,7 @@ public class BariumChain {
         // (H20)CaCO3 -> H2O + CaCO3
         CENTRIFUGE_RECIPES.recipeBuilder().duration(200).EUt(30)
                 .fluidInputs(CalciumCarbonateSolution.getFluid(1000))
-                .output(dust, Calcite, 5)
+                .output(dust, Calcite, 1)
                 .fluidOutputs(Water.getFluid(1000))
                 .buildAndRegister();
 


### PR DESCRIPTION
fixes a calcium dupe in barium line so changed it from 5 to 1 to match the output of the chemical reactor recipe