### PR TITLE
Fix Taranium Advanced Fusion recipe

### DIFF
--- a/src/main/java/gregicadditions/recipes/chain/TaraniumChain.java
+++ b/src/main/java/gregicadditions/recipes/chain/TaraniumChain.java
@@ -287,7 +287,7 @@ public class TaraniumChain {
                 .buildAndRegister();
 
 
-        ADV_FUSION_RECIPES.recipeBuilder().duration(100).EUt(650000).coilTier(2).euStart(1200000000L).euReturn(75)
+        ADV_FUSION_RECIPES.recipeBuilder().duration(100).EUt(120000).coilTier(2).euStart(1200000000L).euReturn(75)
                 .fluidInputs(TaraniumEnrichedLHelium3.getFluid(1000))
                 .fluidInputs(Helium3.getFluid(1000))
                 .fluidOutputs(TaraniumRichDustyHeliumPlasma.getFluid(3000))

--- a/src/main/java/gregicadditions/recipes/chain/TaraniumChain.java
+++ b/src/main/java/gregicadditions/recipes/chain/TaraniumChain.java
@@ -287,7 +287,7 @@ public class TaraniumChain {
                 .buildAndRegister();
 
 
-        ADV_FUSION_RECIPES.recipeBuilder().duration(100).EUt(16000000).coilTier(1).euStart(1200000000L).euReturn(75)
+        ADV_FUSION_RECIPES.recipeBuilder().duration(100).EUt(160000).coilTier(1).euStart(1200000000L).euReturn(75)
                 .fluidInputs(TaraniumEnrichedLHelium3.getFluid(1000))
                 .fluidInputs(Helium3.getFluid(1000))
                 .fluidOutputs(TaraniumRichDustyHeliumPlasma.getFluid(3000))

--- a/src/main/java/gregicadditions/recipes/chain/TaraniumChain.java
+++ b/src/main/java/gregicadditions/recipes/chain/TaraniumChain.java
@@ -287,7 +287,7 @@ public class TaraniumChain {
                 .buildAndRegister();
 
 
-        ADV_FUSION_RECIPES.recipeBuilder().duration(100).EUt(160000).coilTier(1).euStart(1200000000L).euReturn(75)
+        ADV_FUSION_RECIPES.recipeBuilder().duration(100).EUt(650000).coilTier(2).euStart(1200000000L).euReturn(75)
                 .fluidInputs(TaraniumEnrichedLHelium3.getFluid(1000))
                 .fluidInputs(Helium3.getFluid(1000))
                 .fluidOutputs(TaraniumRichDustyHeliumPlasma.getFluid(3000))


### PR DESCRIPTION
It taking UIV voltage means it forces an Mk3 Advanced Fusion
That also means that an mk3 advanced fusion cant overclock it further, and the 5s recipe time means its not even two times faster than in a regular fusion, making this recipe completely unusable, unless you run it in an expensive mk4 or mk5 advanced fusion

This changes the minimum fusion tier to 2, and decreases running voltage to ZPM, meaning that it can 1 tick in an mk3 advanced fusion reactor