### PR TITLE
Buff MEBF (and other megas)

### DIFF
--- a/src/main/java/gregicadditions/machines/multi/mega/MegaMultiblockRecipeMapController.java
+++ b/src/main/java/gregicadditions/machines/multi/mega/MegaMultiblockRecipeMapController.java
@@ -119,10 +119,10 @@ public abstract class MegaMultiblockRecipeMapController extends LargeSimpleRecip
         @Override
         protected Recipe createRecipe(long maxVoltage, IItemHandlerModifiable inputs, IMultipleTankHandler fluidInputs, Recipe matchingRecipe) {
             int EUt;
-            int duration;
+            double duration;
             int minMultiplier = Integer.MAX_VALUE;
             int tier = getOverclockingTier(maxVoltage);
-            int maxParallel = (int) Math.max(Math.pow(4, tier - 6 ), 1);
+            int maxParallel = (int) Math.max(Math.pow(4, tier - 5 ), 1);
 
             Set<ItemStack> countIngredients = new HashSet<>();
             if (matchingRecipe.getInputs().size() != 0) {
@@ -148,7 +148,7 @@ public abstract class MegaMultiblockRecipeMapController extends LargeSimpleRecip
             // Apply Mega Overclocking
             while (duration >= 3 && EUt <= GAValues.V[tier - 1]) {
                 EUt *= 4;
-                duration /= 2;
+                duration /= 2.8;
             }
             if (duration <= 0) {
                 duration = 1;

--- a/src/main/java/gregicadditions/machines/multi/mega/MegaMultiblockRecipeMapController.java
+++ b/src/main/java/gregicadditions/machines/multi/mega/MegaMultiblockRecipeMapController.java
@@ -122,7 +122,7 @@ public abstract class MegaMultiblockRecipeMapController extends LargeSimpleRecip
             double duration;
             int minMultiplier = Integer.MAX_VALUE;
             int tier = getOverclockingTier(maxVoltage);
-            int maxParallel = (int) Math.max(Math.pow(4, tier - 5 ), 1);
+            int maxParallel = (int) Math.max(Math.pow(4, tier - 6 ), 1);
 
             Set<ItemStack> countIngredients = new HashSet<>();
             if (matchingRecipe.getInputs().size() != 0) {

--- a/src/main/java/gregicadditions/machines/multi/mega/MegaMultiblockRecipeMapController.java
+++ b/src/main/java/gregicadditions/machines/multi/mega/MegaMultiblockRecipeMapController.java
@@ -1,5 +1,6 @@
 package gregicadditions.machines.multi.mega;
 
+import gregicadditions.GAValues;
 import gregicadditions.item.GAMultiblockCasing;
 import gregicadditions.item.GAMultiblockCasing2;
 import gregicadditions.machines.multi.simple.LargeSimpleRecipeMapMultiblockController;
@@ -105,10 +106,6 @@ public abstract class MegaMultiblockRecipeMapController extends LargeSimpleRecip
     }
 
     public static class MegaMultiblockRecipeLogic extends LargeSimpleMultiblockRecipeLogic {
-
-        protected static final int OVERCLOCK_FACTOR = 2;
-        protected static final int MAX_ITEMS_LIMIT = 6144;
-
         public MegaMultiblockRecipeLogic(RecipeMapMultiblockController tileEntity, int EUtPercentage, int durationPercentage, int chancePercentage) {
             super(tileEntity, EUtPercentage, durationPercentage, chancePercentage, 256);
         }
@@ -124,18 +121,20 @@ public abstract class MegaMultiblockRecipeMapController extends LargeSimpleRecip
             int EUt;
             int duration;
             int minMultiplier = Integer.MAX_VALUE;
+            int tier = getOverclockingTier(maxVoltage);
+            int maxParallel = (int) Math.max(Math.pow(4, tier - 6 ), 1);
 
             Set<ItemStack> countIngredients = new HashSet<>();
             if (matchingRecipe.getInputs().size() != 0) {
                 this.findIngredients(countIngredients, inputs);
-                minMultiplier = this.getMinRatioItem(countIngredients, matchingRecipe, MAX_ITEMS_LIMIT);
+                minMultiplier = this.getMinRatioItem(countIngredients, matchingRecipe, maxParallel);
             }
 
             Map<String, Integer> countFluid = new HashMap<>();
             if (matchingRecipe.getFluidInputs().size() != 0) {
 
                 this.findFluid(countFluid, fluidInputs);
-                minMultiplier = this.getMinRatioFluid(countFluid, matchingRecipe, MAX_ITEMS_LIMIT);
+                minMultiplier = this.getMinRatioFluid(countFluid, matchingRecipe, maxParallel);
             }
 
             if (minMultiplier == Integer.MAX_VALUE) {
@@ -146,20 +145,22 @@ public abstract class MegaMultiblockRecipeMapController extends LargeSimpleRecip
             EUt = matchingRecipe.getEUt();
             duration = matchingRecipe.getDuration();
 
-            // Get parallel recipes to run: [0, 256]
-            int multiplier = Math.min(minMultiplier, (int) (getMaxVoltage() / EUt));
+            // Apply Mega Overclocking
+            while (duration >= 3 && EUt <= GAValues.V[tier - 1]) {
+                EUt *= 4;
+                duration /= 2;
+            }
+            if (duration <= 0) {
+                duration = 1;
+            }
 
             List<CountableIngredient> newRecipeInputs = new ArrayList<>();
             List<FluidStack> newFluidInputs = new ArrayList<>();
             List<ItemStack> outputI = new ArrayList<>();
             List<FluidStack> outputF = new ArrayList<>();
-            this.multiplyInputsAndOutputs(newRecipeInputs, newFluidInputs, outputI, outputF, matchingRecipe, multiplier);
+            this.multiplyInputsAndOutputs(newRecipeInputs, newFluidInputs, outputI, outputF, matchingRecipe, minMultiplier);
 
-            // Get EUt for the recipe, pre overclocking
-            long totalEUt = (long) multiplier * EUt;
 
-            EUt = (int) (totalEUt / OVERCLOCK_FACTOR);
-            duration /= OVERCLOCK_FACTOR;
 
             RecipeBuilder<?> newRecipe = recipeMap.recipeBuilder();
             copyChancedItemOutputs(newRecipe, matchingRecipe, minMultiplier);

--- a/src/main/java/gregicadditions/machines/multi/mega/MetaTileEntityMegaBlastFurnace.java
+++ b/src/main/java/gregicadditions/machines/multi/mega/MetaTileEntityMegaBlastFurnace.java
@@ -192,7 +192,6 @@ public class MetaTileEntityMegaBlastFurnace extends MegaMultiblockRecipeMapContr
         tooltip.add(I18n.format("gtadditions.multiblock.universal.tooltip.1", this.recipeMap.getLocalizedName()));
         tooltip.add(I18n.format("gtadditions.multiblock.mega_logic.tooltip.1"));
         tooltip.add(I18n.format("gtadditions.multiblock.mega_logic.tooltip.2"));
-        tooltip.add(I18n.format("gtadditions.multiblock.mega_logic.tooltip.3"));
         tooltip.add(I18n.format("gtadditions.multiblock.electric_blast_furnace.tooltip.1"));
         tooltip.add(I18n.format("gtadditions.multiblock.electric_blast_furnace.tooltip.2"));
         tooltip.add(I18n.format("gtadditions.multiblock.electric_blast_furnace.tooltip.3"));
@@ -267,11 +266,11 @@ public class MetaTileEntityMegaBlastFurnace extends MegaMultiblockRecipeMapContr
         @Override
         protected Recipe createRecipe(long maxVoltage, IItemHandlerModifiable inputs, IMultipleTankHandler fluidInputs, Recipe matchingRecipe) {
             long EUt;
-            int duration;
+            double duration;
             int minMultiplier = Integer.MAX_VALUE;
             int recipeTemp = matchingRecipe.getRecipePropertyStorage().getRecipePropertyValue(BlastTemperatureProperty.getInstance(), 0);
             int tier = getOverclockingTier(maxVoltage);
-            int maxParallel = (int) Math.max(Math.pow(4, tier - 6 ), 1);
+            int maxParallel = (int) Math.max(Math.pow(4, tier - 5 ), 1);
 
             Set<ItemStack> countIngredients = new HashSet<>();
             if (matchingRecipe.getInputs().size() != 0) {
@@ -312,7 +311,7 @@ public class MetaTileEntityMegaBlastFurnace extends MegaMultiblockRecipeMapContr
             // Apply Mega Overclocking
             while (duration >= 3 && EUt <= GAValues.V[tier - 1]) {
                 EUt *= 4;
-                duration /= 2;
+                duration /= 2.8;
             }
             if (duration <= 0) {
                 duration = 1;
@@ -341,7 +340,7 @@ public class MetaTileEntityMegaBlastFurnace extends MegaMultiblockRecipeMapContr
                     .outputs(outputI)
                     .fluidOutputs(outputF)
                     .EUt((int) Math.max(1, EUt))
-                    .duration(duration)
+                    .duration((int) duration)
                     .blastFurnaceTemp(recipeTemp);
 
             return newRecipe.build().getResult();

--- a/src/main/java/gregicadditions/machines/multi/mega/MetaTileEntityMegaBlastFurnace.java
+++ b/src/main/java/gregicadditions/machines/multi/mega/MetaTileEntityMegaBlastFurnace.java
@@ -270,7 +270,7 @@ public class MetaTileEntityMegaBlastFurnace extends MegaMultiblockRecipeMapContr
             int minMultiplier = Integer.MAX_VALUE;
             int recipeTemp = matchingRecipe.getRecipePropertyStorage().getRecipePropertyValue(BlastTemperatureProperty.getInstance(), 0);
             int tier = getOverclockingTier(maxVoltage);
-            int maxParallel = (int) Math.max(Math.pow(4, tier - 5 ), 1);
+            int maxParallel = (int) Math.max(Math.pow(4, tier - 6 ), 1);
 
             Set<ItemStack> countIngredients = new HashSet<>();
             if (matchingRecipe.getInputs().size() != 0) {

--- a/src/main/java/gregicadditions/machines/multi/mega/MetaTileEntityMegaBlastFurnace.java
+++ b/src/main/java/gregicadditions/machines/multi/mega/MetaTileEntityMegaBlastFurnace.java
@@ -191,8 +191,11 @@ public class MetaTileEntityMegaBlastFurnace extends MegaMultiblockRecipeMapContr
     public void addInformation(ItemStack stack, @Nullable World player, List<String> tooltip, boolean advanced) {
         tooltip.add(I18n.format("gtadditions.multiblock.universal.tooltip.1", this.recipeMap.getLocalizedName()));
         tooltip.add(I18n.format("gtadditions.multiblock.mega_logic.tooltip.1"));
-        tooltip.add(I18n.format("gtadditions.multiblock.mega_blast_logic.tooltip.1"));
-        tooltip.add(I18n.format("gtadditions.multiblock.mega_blast_logic.tooltip.2"));
+        tooltip.add(I18n.format("gtadditions.multiblock.mega_logic.tooltip.2"));
+        tooltip.add(I18n.format("gtadditions.multiblock.mega_logic.tooltip.3"));
+        tooltip.add(I18n.format("gtadditions.multiblock.electric_blast_furnace.tooltip.1"));
+        tooltip.add(I18n.format("gtadditions.multiblock.electric_blast_furnace.tooltip.2"));
+        tooltip.add(I18n.format("gtadditions.multiblock.electric_blast_furnace.tooltip.3"));
     }
 
     @Override

--- a/src/main/java/gregicadditions/machines/multi/mega/MetaTileEntityMegaDistillationTower.java
+++ b/src/main/java/gregicadditions/machines/multi/mega/MetaTileEntityMegaDistillationTower.java
@@ -46,7 +46,7 @@ public class MetaTileEntityMegaDistillationTower extends MegaMultiblockRecipeMap
         tooltip.add(I18n.format("gtadditions.multiblock.universal.tooltip.1", this.recipeMap.getLocalizedName()));
         tooltip.add(I18n.format("gtadditions.multiblock.mega_logic.tooltip.1"));
         tooltip.add(I18n.format("gtadditions.multiblock.mega_logic.tooltip.2"));
-        tooltip.add(I18n.format("gtadditions.multiblock.mega_logic.tooltip.3", 1.0));
+        tooltip.add(I18n.format("gtadditions.multiblock.mega_logic.tooltip.3"));
     }
 
     @Override

--- a/src/main/java/gregicadditions/machines/multi/mega/MetaTileEntityMegaDistillationTower.java
+++ b/src/main/java/gregicadditions/machines/multi/mega/MetaTileEntityMegaDistillationTower.java
@@ -33,7 +33,7 @@ public class MetaTileEntityMegaDistillationTower extends MegaMultiblockRecipeMap
     };
 
     public MetaTileEntityMegaDistillationTower(ResourceLocation metaTileEntityId) {
-        super(metaTileEntityId, DISTILLATION_RECIPES, 100, 200, 100, 0);
+        super(metaTileEntityId, DISTILLATION_RECIPES, 100, 100, 100, 0);
     }
 
     @Override

--- a/src/main/java/gregicadditions/machines/multi/mega/MetaTileEntityMegaVacuumFreezer.java
+++ b/src/main/java/gregicadditions/machines/multi/mega/MetaTileEntityMegaVacuumFreezer.java
@@ -33,7 +33,7 @@ public class MetaTileEntityMegaVacuumFreezer extends MegaMultiblockRecipeMapCont
     };
 
     public MetaTileEntityMegaVacuumFreezer(ResourceLocation metaTileEntityId) {
-        super(metaTileEntityId, VACUUM_RECIPES, 100, 200, 100, 0);
+        super(metaTileEntityId, VACUUM_RECIPES, 100, 100, 100, 0);
     }
 
     @Override

--- a/src/main/java/gregicadditions/machines/multi/mega/MetaTileEntityMegaVacuumFreezer.java
+++ b/src/main/java/gregicadditions/machines/multi/mega/MetaTileEntityMegaVacuumFreezer.java
@@ -66,7 +66,7 @@ public class MetaTileEntityMegaVacuumFreezer extends MegaMultiblockRecipeMapCont
         tooltip.add(I18n.format("gtadditions.multiblock.universal.tooltip.1", this.recipeMap.getLocalizedName()));
         tooltip.add(I18n.format("gtadditions.multiblock.mega_logic.tooltip.1"));
         tooltip.add(I18n.format("gtadditions.multiblock.mega_logic.tooltip.2"));
-        tooltip.add(I18n.format("gtadditions.multiblock.mega_logic.tooltip.3", 1.0));
+        tooltip.add(I18n.format("gtadditions.multiblock.mega_logic.tooltip.3"));
     }
 
     public static final IBlockState casingState = MetaBlocks.METAL_CASING.getState(BlockMetalCasing.MetalCasingType.ALUMINIUM_FROSTPROOF);

--- a/src/main/resources/assets/gtadditions/lang/en_us.lang
+++ b/src/main/resources/assets/gtadditions/lang/en_us.lang
@@ -3123,9 +3123,8 @@ gtadditions.multiblock.battery_tower.passive_drain=Passive EU loss per tick: %s
 
 gtadditions.multiblock.blast_furnace.additional_temperature=Additional Temperature: %dK
 
-gtadditions.multiblock.mega_logic.tooltip.1=Parallels quadruple each voltage above LuV, starting with 1 at LuV.
+gtadditions.multiblock.mega_logic.tooltip.1=Parallels quadruple each voltage above IV, starting with 1 at IV.
 gtadditions.multiblock.mega_logic.tooltip.2=Parallels doesn't use additional energy.
-gtadditions.multiblock.mega_logic.tooltip.3=Overclocks halves duration and quadruples energy usage.
 
 gtadditions.multiblock.chemical_plant.tooltip.1=Does not run in parallel when running chemical plant recipes.
 

--- a/src/main/resources/assets/gtadditions/lang/en_us.lang
+++ b/src/main/resources/assets/gtadditions/lang/en_us.lang
@@ -3123,7 +3123,7 @@ gtadditions.multiblock.battery_tower.passive_drain=Passive EU loss per tick: %s
 
 gtadditions.multiblock.blast_furnace.additional_temperature=Additional Temperature: %dK
 
-gtadditions.multiblock.mega_logic.tooltip.1=Parallels quadruple each voltage above IV, starting with 1 at IV.
+gtadditions.multiblock.mega_logic.tooltip.1=Parallels quadruple each voltage above LuV, starting with 1 at LuV.
 gtadditions.multiblock.mega_logic.tooltip.2=Parallels doesn't use additional energy.
 
 gtadditions.multiblock.chemical_plant.tooltip.1=Does not run in parallel when running chemical plant recipes.

--- a/src/main/resources/assets/gtadditions/lang/en_us.lang
+++ b/src/main/resources/assets/gtadditions/lang/en_us.lang
@@ -3123,12 +3123,9 @@ gtadditions.multiblock.battery_tower.passive_drain=Passive EU loss per tick: %s
 
 gtadditions.multiblock.blast_furnace.additional_temperature=Additional Temperature: %dK
 
-gtadditions.multiblock.mega_logic.tooltip.1=Max Parallel: §e512
-gtadditions.multiblock.mega_logic.tooltip.2=EU/t Usage: §eParallel Amount * Recipe EU/t * 0.5
-gtadditions.multiblock.mega_logic.tooltip.3=Duration Multiplier: §e%d
-
-gtadditions.multiblock.mega_blast_logic.tooltip.1=EU/t Usage: §eParallel Amount * Recipe EU/t
-gtadditions.multiblock.mega_blast_logic.tooltip.2=Prioritizes Parallel Recipes over Heating Coil Bonuses.
+gtadditions.multiblock.mega_logic.tooltip.1=Parallels quadruple each voltage above LuV, starting with 1 at LuV.
+gtadditions.multiblock.mega_logic.tooltip.2=Parallels doesn't use additional energy.
+gtadditions.multiblock.mega_logic.tooltip.3=Overclocks halves duration and quadruples energy usage.
 
 gtadditions.multiblock.chemical_plant.tooltip.1=Does not run in parallel when running chemical plant recipes.
 


### PR DESCRIPTION
Changes parallels to not use energy, similarly to other GCYL multiblocks
Instead of static parallels, it quadruples it every voltage after LuV
LuV (and below): 1
ZPM: 4  
UV: 16
UHV: 64
UEV: 256
UIV: 1024
UMV: 4096
UXV: 16384

Comparison (outdated): https://discord.com/channels/796142800018079794/796142800533454909/1361645538856144928 