### PR TITLE
Jei garecipe categories

### DIFF
--- a/src/main/java/gregicadditions/integrations/jei/utils/render/FluidStackTextRenderer.java
+++ b/src/main/java/gregicadditions/integrations/jei/utils/render/FluidStackTextRenderer.java
@@ -11,6 +11,7 @@ import net.minecraftforge.fluids.FluidStack;
 
 import javax.annotation.Nullable;
 
+@Deprecated
 public class FluidStackTextRenderer extends FluidStackRenderer {
     public FluidStackTextRenderer(int capacityMb, boolean showCapacity, int width, int height, @Nullable IDrawable overlay) {
         super(capacityMb, showCapacity, width, height, overlay);

--- a/src/main/java/gregicadditions/jei/JEIGAPlugin.java
+++ b/src/main/java/gregicadditions/jei/JEIGAPlugin.java
@@ -90,7 +90,7 @@ public class JEIGAPlugin implements IModPlugin {
         for (RecipeMap<?> recipeMap : RecipeMap.getRecipeMaps()) {
             List<GARecipeWrapper> recipesList = recipeMap.getRecipeList()
                     .stream().filter(recipe -> !recipe.isHidden() && recipe.hasValidInputsForDisplay())
-                    .map(r -> new GARecipeWrapper(r))
+                    .map(recipe -> new GARecipeWrapper(recipeMap, recipe))
                     .collect(Collectors.toList());
             registry.addRecipes(recipesList, Gregicality.MODID + ":" + recipeMap.unlocalizedName);
         }

--- a/src/main/java/gregicadditions/recipes/compat/jei/GARecipeMapCategory.java
+++ b/src/main/java/gregicadditions/recipes/compat/jei/GARecipeMapCategory.java
@@ -8,8 +8,11 @@ import gregtech.api.gui.ModularUI;
 import gregtech.api.gui.Widget;
 import gregtech.api.gui.widgets.SlotWidget;
 import gregtech.api.gui.widgets.TankWidget;
+import gregtech.api.recipes.CountableIngredient;
 import gregtech.api.recipes.RecipeMap;
+import gregtech.integration.jei.utils.JEIHelpers;
 import gregtech.integration.jei.utils.render.FluidStackTextRenderer;
+import gregtech.integration.jei.utils.render.ItemStackTextRenderer;
 import mcp.MethodsReturnNonnullByDefault;
 import mezz.jei.api.IGuiHelper;
 import mezz.jei.api.gui.IDrawable;
@@ -90,14 +93,12 @@ public class GARecipeMapCategory implements IRecipeCategory<GARecipeWrapper> {
                 SlotItemHandler handle = (SlotItemHandler) slotWidget.getHandle();
                 if (handle.getItemHandler() == importItems) {
                     //this is input item stack slot widget, so add it to item group
-                    itemStackGroup.init(handle.getSlotIndex(), true,
-                            slotWidget.getPosition().x,
-                            slotWidget.getPosition().y);
+                    itemStackGroup.init(handle.getSlotIndex(), true, new ItemStackTextRenderer(recipeWrapper.getIngredientConsumable().get(handle.getSlotIndex())),
+                            slotWidget.getPosition().x, slotWidget.getPosition().y, slotWidget.getSize().getWidth(), slotWidget.getSize().getHeight(), 0, 0);
                 } else if (handle.getItemHandler() == exportItems) {
                     //this is output item stack slot widget, so add it to item group
-                    itemStackGroup.init(importItems.getSlots() + handle.getSlotIndex(), false,
-                            slotWidget.getPosition().x,
-                            slotWidget.getPosition().y);
+                    itemStackGroup.init(importItems.getSlots() + handle.getSlotIndex(), false, new ItemStackTextRenderer(true),
+                            slotWidget.getPosition().x, slotWidget.getPosition().y, slotWidget.getSize().getWidth(), slotWidget.getSize().getHeight(), 0, 0);
                 }
 
             } else if (uiWidget instanceof TankWidget) {

--- a/src/main/java/gregicadditions/recipes/compat/jei/GARecipeMapCategory.java
+++ b/src/main/java/gregicadditions/recipes/compat/jei/GARecipeMapCategory.java
@@ -8,9 +8,7 @@ import gregtech.api.gui.ModularUI;
 import gregtech.api.gui.Widget;
 import gregtech.api.gui.widgets.SlotWidget;
 import gregtech.api.gui.widgets.TankWidget;
-import gregtech.api.recipes.CountableIngredient;
 import gregtech.api.recipes.RecipeMap;
-import gregtech.integration.jei.utils.JEIHelpers;
 import gregtech.integration.jei.utils.render.FluidStackTextRenderer;
 import gregtech.integration.jei.utils.render.ItemStackTextRenderer;
 import mcp.MethodsReturnNonnullByDefault;
@@ -97,7 +95,9 @@ public class GARecipeMapCategory implements IRecipeCategory<GARecipeWrapper> {
                             slotWidget.getPosition().x, slotWidget.getPosition().y, slotWidget.getSize().getWidth(), slotWidget.getSize().getHeight(), 0, 0);
                 } else if (handle.getItemHandler() == exportItems) {
                     //this is output item stack slot widget, so add it to item group
-                    itemStackGroup.init(importItems.getSlots() + handle.getSlotIndex(), false, new ItemStackTextRenderer(true),
+                    int slot = this.importItems.getSlots() + handle.getSlotIndex();
+                    int[] chances = recipeWrapper.getChanceEntries().get(slot);
+                    itemStackGroup.init(slot, false, new ItemStackTextRenderer(chances != null ? chances[0] : 0, chances != null ? chances[1] : 0),
                             slotWidget.getPosition().x, slotWidget.getPosition().y, slotWidget.getSize().getWidth(), slotWidget.getSize().getHeight(), 0, 0);
                 }
 

--- a/src/main/java/gregicadditions/recipes/compat/jei/GARecipeMapCategory.java
+++ b/src/main/java/gregicadditions/recipes/compat/jei/GARecipeMapCategory.java
@@ -1,7 +1,6 @@
 package gregicadditions.recipes.compat.jei;
 
 import gregicadditions.Gregicality;
-import gregicadditions.integrations.jei.utils.render.FluidStackTextRenderer;
 import gregtech.api.capability.impl.FluidTankList;
 import gregtech.api.gui.BlankUIHolder;
 import gregtech.api.gui.IRenderContext;
@@ -10,6 +9,7 @@ import gregtech.api.gui.Widget;
 import gregtech.api.gui.widgets.SlotWidget;
 import gregtech.api.gui.widgets.TankWidget;
 import gregtech.api.recipes.RecipeMap;
+import gregtech.integration.jei.utils.render.FluidStackTextRenderer;
 import mcp.MethodsReturnNonnullByDefault;
 import mezz.jei.api.IGuiHelper;
 import mezz.jei.api.gui.IDrawable;

--- a/src/main/java/gregicadditions/recipes/compat/jei/GARecipeWrapper.java
+++ b/src/main/java/gregicadditions/recipes/compat/jei/GARecipeWrapper.java
@@ -65,7 +65,6 @@ public class GARecipeWrapper implements IRecipeWrapper {
             recipeInputs.forEach(stack -> {
                 if (stack.amount == 0) {
                     notConsumedFluidInput.add(stack);
-                    stack.amount = 1;
                 }
             });
             ingredients.setInputs(VanillaTypes.FLUID, recipeInputs);


### PR DESCRIPTION
- Add indicators for non-consumable and chanced outputs in JEI recipes. 
- Hold shift to view boost per tier instead of base chance.